### PR TITLE
Fixing the error for ApplicationObjectID

### DIFF
--- a/tools/packerinfo.ps1
+++ b/tools/packerinfo.ps1
@@ -4,6 +4,6 @@ $subscription = Get-AzureRmSubscription
 Write-Host 'Subscription Id :'  $subscription.SubscriptionId 
 Write-Host 'TenantId : '  $subscription.TenantId
 $appobj = Get-AzureRmADApplication -DisplayNameStartWith 'testdemo'
-Write-Host 'Objectid' $appobj[0].ApplicationObjectId.ToString()
+Write-Host 'Objectid' $appobj[0].ObjectId.ToString()
 write-Host  'clientid' $appobj[0].ApplicationId.ToString()
 write-Host  'clientsecret Refer AzureADSPNConfig.ps1' 


### PR DESCRIPTION
PSADApplication object does not have ApplicationObjectID property, so throws: "You cannot call a method on a null-valued expression." Fixed by replacing ObjectID
